### PR TITLE
Local Development Environment

### DIFF
--- a/.develop/.htaccess
+++ b/.develop/.htaccess
@@ -1,0 +1,10 @@
+# Apache 2.2
+<IfModule !mod_authz_core>
+   Order Deny,Allow
+   Deny from all
+</IfModule>
+
+# Apache 2.4
+<IfModule mod_authz_core>
+   Require all denied
+</IfModule>

--- a/.develop/Berksfile
+++ b/.develop/Berksfile
@@ -1,0 +1,9 @@
+# -*- mode: ruby -*-
+source 'https://supermarket.chef.io'
+
+def cli_cookbook(name, version = '= 0.9.0', options = {})
+  #cookbook name, version, { path: "~/code/cli-cookbooks/cookbooks/#{name}" }.merge(options)
+  cookbook name, version, { git: 'git@github.com:CarnegieLearningWeb/cli-cookbooks', branch: 'master', rel: "cookbooks/#{name}" }.merge(options)
+end
+
+cli_cookbook 'clw-apache2'

--- a/.develop/Berksfile.lock
+++ b/.develop/Berksfile.lock
@@ -1,0 +1,13 @@
+DEPENDENCIES
+  clw-apache2
+    git: git@github.com:CarnegieLearningWeb/cli-cookbooks
+    revision: 953d8ffd00b8564349f34db84b40bcd1f7bbf383
+    branch: master
+    rel: cookbooks/clw-apache2
+
+GRAPH
+  apache2 (5.0.1)
+  apt (6.1.4)
+  clw-apache2 (0.9.0)
+    apache2 (~> 5.0.1)
+    apt (~> 6.1.4)

--- a/.develop/README.md
+++ b/.develop/README.md
@@ -1,0 +1,21 @@
+# Local development environment for this repository
+
+## Requirements:
+
+### Software:
+1. Vagrant
+2. VirtualBox
+
+### Other:
+1. Create a file at `includes/server.php` with the appropriate content
+2. You need GitHub ssh access to CarnegieLearningWeb/cli-cookbooks
+
+### Steps:
+
+Run:
+`vagrant up`
+
+Access Locally:
+http://cl-emcschool.qa-cli.com/
+
+**Note:** the .develop/ directory should be excluded from server deployments

--- a/.develop/Vagrantfile
+++ b/.develop/Vagrantfile
@@ -1,0 +1,145 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+require 'yaml'
+require 'json'
+
+# Read YAML file with box details
+servers = YAML.load_file('project.yml')
+
+# Required to shim opsworks deploy event
+#deploy = JSON.parse(IO.read('deploy.json'))
+
+# Local file to override chef attributes
+JSON_CONFIG = File.expand_path(File.join('~', 'chef-cookbooks.json'))
+if File.exists?(JSON_CONFIG) then
+  deploy = deploy.merge(JSON.parse(IO.read(JSON_CONFIG)))
+end
+
+# If we have a user configuration file load that to potentially override these constants
+USER_CONFIG = File.expand_path(File.join('~', '.cli-vagrant.rb'))
+if File.exists?(USER_CONFIG) then
+  eval(IO.read(USER_CONFIG), binding)
+end
+
+# Current user, used primarily by vagrant
+CURRENT_USER = Etc.getlogin unless defined? CURRENT_USER
+OUTBOUND_EMAIL = "#{CURRENT_USER}@carnegielearning.com" unless defined? OUTBOUND_EMAIL
+DOMAIN_NAME = 'cl.local' unless defined? DOMAIN_NAME
+
+# default VM options (used in config.vm.define constructor)
+opts = {
+    :primary => false,
+    :autostart => true
+}
+
+required_plugins = [
+    'vagrant-berkshelf'
+]
+
+suggested_plugins = [
+    'vagrant-hostmanager'
+]
+
+required_plugins.each do |plugin|
+    unless Vagrant.has_plugin?(plugin)
+      abort("Missing required plugin `#{plugin}'.\nInstall it with the following command:\nvagrant plugin install #{plugin}")
+    end
+end
+
+suggested_plugins.each do |plugin|
+    unless Vagrant.has_plugin?(plugin)
+      warn("Missing suggested plugin `#{plugin}'.\nInstall it with the following command:\nvagrant plugin install #{plugin}")
+    end
+end
+
+
+Vagrant.configure("2") do |config|
+
+    # This is a multi-machine environment
+    # Put the global settings at the top
+
+    config.ssh.forward_agent = true
+    config.ssh.shell = "bash"
+    config.ssh.insert_key = true
+    config.ssh.verify_host_key = false
+
+    config.berkshelf.enabled = true
+
+    if Vagrant.has_plugin?('vagrant-hostmanager')
+        config.hostmanager.enabled = true
+        config.hostmanager.manage_host = true
+        config.hostmanager.ignore_private_ip = false
+    end
+
+    servers.each do |details|
+        warn("Processing Vagrant box #{details['name']}")
+        opts[:primary] = servers[0]['name'] == details['name'] ? true : false
+        opts[:autostart] = details.has_key?('required') ? details['required'] : false
+        config.vm.define details['name'], opts do |mach|
+            mach.vm.box = details['box']
+            mach.vm.box_url = details['box']
+            mach.vm.hostname = "#{CURRENT_USER}-#{details['name']}"
+            mach.vm.network(:private_network, {:ip=>details['ip']}) if details.has_key?('ip')
+            if details['ports']
+                details['ports'].each do |guest,host|
+                    mach.vm.network(:forwarded_port, {:guest=>guest, :host=>host, :auto_correct => true})
+                end
+            end
+
+            if File.exists?(ENV['HOME']+'/.composer')
+                mach.vm.synced_folder ENV['HOME']+"/.composer", "/home/vagrant/.composer"
+            end
+
+            if details['projects']
+                details['projects'].each do |proj,path|
+                    if File.exists?(path)
+                        #warn("Mapping project directory #{path} for #{proj}")
+                        mach.vm.synced_folder path, "/srv/www/#{proj}/current",
+                            :nfs => true,
+                            :bsd__nfs_options => ['alldirs']
+                    else
+                        warn("No directory found at #{path} for #{proj}")
+                    end
+                end
+            end
+
+            if details['mappings']
+                details['mappings'].each do |vpath,lpath|
+                    if File.exists?(lpath)
+                        mach.vm.synced_folder lpath, vpath,
+                            :nfs => true,
+                            :bsd__nfs_options => ['alldirs']
+                    else
+                        warn("No directory found at #{lpath} for #{vpath}")
+                    end
+                end
+            end
+
+            mach.vm.provider :virtualbox do |vb|
+                vb.customize ['modifyvm', :id, '--memory', details['memory']]
+                vb.customize ['modifyvm', :id, '--cpus', details['cpus']]
+                vb.customize ["modifyvm", :id, "--nataliasmode1", "proxyonly"]
+                vb.customize ["modifyvm", :id, "--nataliasmode1", "sameports"]
+                vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
+                vb.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
+                vb.customize ["guestproperty", "set", :id, "/VirtualBox/GuestAdd/VBoxService/--timesync-set-threshold", 10000]
+            end
+            if details['aliases'] && Vagrant.has_plugin?('vagrant-hostmanager')
+                mach.hostmanager.aliases = details['aliases']
+            end
+            mach.vm.provision :chef_solo do |chef|
+                chef.version = "12.18.31"
+                chef.environments_path = 'chef'
+                chef.environment = 'vagrant'
+                chef.roles_path = 'chef'
+                details['run_list'].each do |rl|
+                    chef.add_recipe rl
+                end if details['run_list']
+                details['role'].each do |rl|
+                    chef.add_role rl
+                end if details['role']
+            end
+        end
+    end
+end

--- a/.develop/Vagrantfile
+++ b/.develop/Vagrantfile
@@ -62,7 +62,9 @@ Vagrant.configure("2") do |config|
     config.ssh.forward_agent = true
     config.ssh.shell = "bash"
     config.ssh.insert_key = true
-    config.ssh.verify_host_key = false
+    if Vagrant::VERSION >= '2.0.2'
+        config.ssh.verify_host_key = false
+    end
 
     config.berkshelf.enabled = true
 

--- a/.develop/apache2/site.conf
+++ b/.develop/apache2/site.conf
@@ -1,0 +1,41 @@
+<VirtualHost *:80>
+  ServerName cl-emcschool.qa-cli.com
+  ServerAlias emcschool.cl.local
+  DocumentRoot /srv/www/emcp/current/
+
+  RewriteEngine On
+
+  RewriteCond %{HTTP:X-Forwarded-Proto} 'http' [NC,OR]
+  RewriteCond %{HTTPS} !=on [NC]
+  RewriteRule ^(.*)$ - [env=proto:http]
+  RewriteCond %{HTTP:X-Forwarded-Proto} 'https' [NC,OR]
+  RewriteCond %{HTTPS} =on [NC]
+  RewriteRule ^(.*)$ - [env=proto:https]
+
+  <Directory /srv/www/emcp/current/>
+    AllowOverride all
+    <IfModule mod_authz_core.c>
+        Require all granted
+    </IfModule>
+    <IfModule !mod_authz_core.c>
+        Order deny,allow
+        Allow from all
+    </IfModule>
+  </Directory>
+
+  <Location />
+    Options FollowSymLinks
+    AllowOverride all
+    <IfModule mod_authz_core.c>
+        Require all granted
+    </IfModule>
+    <IfModule !mod_authz_core.c>
+        Order deny,allow
+        Allow from all
+    </IfModule>
+  </Location>
+
+  LogLevel warn
+  ErrorLog /var/log/apache2/emcp-error.log
+  CustomLog /var/log/apache2/emcp-access.log combined
+</VirtualHost>

--- a/.develop/chef/vagrant.json
+++ b/.develop/chef/vagrant.json
@@ -3,9 +3,5 @@
     "json_class":"Chef::Environment",
     "chef_type":"environment",
     "default_attributes": {
-        "apache": {
-            "user": "www-data",
-            "group": "www-data"
-        }
     }
 }

--- a/.develop/chef/vagrant.json
+++ b/.develop/chef/vagrant.json
@@ -1,0 +1,11 @@
+{
+    "name":"vagrant",
+    "json_class":"Chef::Environment",
+    "chef_type":"environment",
+    "default_attributes": {
+        "apache": {
+            "user": "www-data",
+            "group": "www-data"
+        }
+    }
+}

--- a/.develop/project.yml
+++ b/.develop/project.yml
@@ -1,0 +1,14 @@
+- name: 'emcp'
+  required: true
+  box: 'ubuntu/xenial64'
+  memory: 512
+  cpus: 1
+  ip: '172.28.129.28'
+  projects:
+    emcp: '..'
+  mappings:
+    '/etc/apache2/sites-enabled': './apache2'
+  aliases:
+    - 'emcschool.cl.local'
+  run_list:
+    - 'clw-apache2'

--- a/.gitignore
+++ b/.gitignore
@@ -211,6 +211,9 @@ pip-log.txt
 #Translations
 *.mo
 
+# Vagrant
+.vagrant/
+
 #Mr Developer
 .mr.developer.cfg
 includes/server.php

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1,11 +1,12 @@
 <?php
 
-    if(empty($_SERVER['HTTPS']) || $_SERVER['HTTPS'] == "off") {
-        $redirect = 'https://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
-        header('HTTP/1.1 301 Moved Permanently');
-        header('Location: ' . $redirect);
-        exit();
-    }
+   # Handle this in the Apache configuration file instead
+   # if(empty($_SERVER['HTTPS']) || $_SERVER['HTTPS'] == "off") {
+   #     $redirect = 'https://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
+   #     header('HTTP/1.1 301 Moved Permanently');
+   #     header('Location: ' . $redirect);
+   #     exit();
+   # }
 
 	$current = basename(getcwd());
 
@@ -14,7 +15,7 @@
 			return ' class="current"';
 		}
 	}
-	
+
 	if( $current == 'spanish' || $current == 'french' || $current == 'german' || $current == 'chinese' || $current == 'italian' || $current == 'japanese' || $current == 'arabic') {
 		$currentwl =  $current;
 	} else {


### PR DESCRIPTION
This PR introduces a standardized environment for local development.  It also begins the process of creating a build / deployment process that is independent of the environment.  Chef recipes can be used with different attributes in different environments.

Two changes in this PR affect files outside of the new `.develop/` directory:
`.gitignore` to ignore the `.vagrant/` directories (standard)
`includes/functions.php` to remove the requirement for SSL from the PHP code.  I usually prefer to do this in the Apache VHost configuration for the site, or, even better, at the load balancer.